### PR TITLE
Squash bug/DLR-2965-fix-sentry-issue-with-undefined-host

### DIFF
--- a/src/Fetch/Message.php
+++ b/src/Fetch/Message.php
@@ -670,7 +670,7 @@ class Message
         $outputAddresses = array();
         if (is_array($addresses))
             foreach ($addresses as $address) {
-                if (property_exists($address, 'mailbox') && $address->mailbox != 'undisclosed-recipients') {
+                if (property_exists($address, 'mailbox') && !empty($address->host)) {
                     $currentAddress = array();
                     $currentAddress['address'] = $address->mailbox . '@' . $address->host;
                     if (isset($address->personal)) {

--- a/src/Fetch/Message.php
+++ b/src/Fetch/Message.php
@@ -670,7 +670,7 @@ class Message
         $outputAddresses = array();
         if (is_array($addresses))
             foreach ($addresses as $address) {
-                if (property_exists($address, 'mailbox') && !empty($address->host)) {
+                if (property_exists($address, 'mailbox') && property_exists($address, 'host') && !empty($address->host)) {
                     $currentAddress = array();
                     $currentAddress['address'] = $address->mailbox . '@' . $address->host;
                     if (isset($address->personal)) {


### PR DESCRIPTION
This change is directly taken from the open pull request to tedious/Fetch:
https://github.com/tedious/Fetch/pull/159
``
this PR is referring to ``https://github.com/tedious/Fetch/issues/95 ``i found the infamous bug of "Undefined property: stdClass::$host" because the mail "To:" header was "undisclosed recipients" (with the space without the dash).
I think it is wiser do not rely on a fixed string, then the pull request. It Works For Me.
``

## Tests
No tests done yet since i do not have the know-how to know how.
If you tell me how to test this i will do.